### PR TITLE
Changed example link to properly open file

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Coming soon...
 ```
 
 #### Web Component integration in any framework
-This component can be built and bundled as a Web Component, which makes it reusable in a variety of stacks. A full, working example can be found [here]('./src/example/index.html').
+This component can be built and bundled as a Web Component, which makes it reusable in a variety of stacks. A full, working example can be found [here](https://github.com/google/workflow-graph/blob/main/src/example/index.html).
 
 ## Next steps
 - [ ] Create a release script and deploy Web Component artifacts (bundle, CSS, typings) to NPM.


### PR DESCRIPTION
Previous link to web component example file was seemingly formatted improperly. If this is intentional, ignore this pr