### PR TITLE
Remove duplicate entries in .gitignore for improved readability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,14 +1,9 @@
 bazel-bin/
-bazel-bin
 bazel-out/
-bazel-out
 bazel-testlogs/
-bazel-testlogs
 bazel-workflow-graph/
-bazel-workflow-graph
 node_modules/
 dist/
 dist-types/
 .angular/
-.angular
 release/


### PR DESCRIPTION
Cleaned up redundant entries in .gitignore by removing duplicates such as
'bazel-bin/' and 'bazel-bin', 'bazel-out/' and 'bazel-out', 'bazel-testlogs/'
and 'bazel-testlogs', and 'bazel-workflow-graph/' and 'bazel-workflow-graph'.
This simplifies the file and enhances its clarity without altering functionality.